### PR TITLE
Turn down logging for the normal case

### DIFF
--- a/sgmon/monitor.py
+++ b/sgmon/monitor.py
@@ -48,7 +48,7 @@ def fetch_tasks_state(url, state):
         try:
             url = url.format(state=state)
             client = HTTPClient(url)
-            logger.info("Fetching tasks state from {}".format(url))
+            logger.debug("Fetching tasks state from {}".format(url))
             return client.get()
         except Exception as err:
             logger.exception("Exception when fetching tasks: {}".format(err))


### PR DESCRIPTION
We don't need to see a message each time it fetches in normal info logging. It's actually confusing our logging system since it contains "ERROR" as part of the string and it's getting relabeled as an error level message.